### PR TITLE
Update LS7366R.cpp

### DIFF
--- a/LS7366R_example/LS7366R.cpp
+++ b/LS7366R_example/LS7366R.cpp
@@ -14,7 +14,9 @@ LS7366R::LS7366R(unsigned char _leftSelect, unsigned char _rightSelect, unsigned
 	rightSelect = _rightSelect;
 
 	pinMode(leftSelect, OUTPUT);
+	digitalWrite(leftSelect, HIGH);   // Set initial state to "not selected"
 	pinMode(rightSelect, OUTPUT);
+	digitalWrite(rightSelect, HIGH);  // Set initial state to "not selected"
 	SPI.begin();
 
 	digitalWrite(leftSelect, LOW);


### PR DESCRIPTION
Very nice library here. I found that the MDR0, MDR1 configuration changes were not taking effect on the right encoder. To fix that, I set the chip select states prior to the first SPI call. (After pinMode() is called, the state of the pin is set to what it was when last set as an output pin but here we don't know the pin's prior state.)
